### PR TITLE
respect prefix in xbrowse paging

### DIFF
--- a/app/controllers/concerns/blacklight_solrplugins/x_browse.rb
+++ b/app/controllers/concerns/blacklight_solrplugins/x_browse.rb
@@ -39,26 +39,24 @@ module BlacklightSolrplugins::XBrowse
     offset, _ = calc_offset_and_expected_pos(dir)
 
     if doc_centric
-      facet_target = target.present? ? target : ''
       # ref is a composite key (target/targetDoc) to disambiguate target
       if ref
         pieces = ref.split('|', 2)
         ref = pieces[0]
         facet_target = pieces[1]
+      else
+        facet_target = target.present? ? JSON.dump(target) : '""'
       end
     else
-      facet_target = ref || target || ''
+      facet_target = ref || JSON.dump(target) || '""'
     end
-
-    # defaults to true
-    jsonify_target = xfacet.jsonify_target.nil? || xfacet.jsonify_target
 
     additional_params = {
       # distrib.singlePass is required in order to make solrplugins
       # include documents in the doc-centric xfacet payloads when running
       # distributed Solr
       'distrib.singlePass' => 'true',
-      "f.#{xfacet.field}.facet.target" => jsonify_target ? JSON.dump(facet_target) : facet_target,
+      "f.#{xfacet.field}.facet.target" => facet_target,
       "f.#{xfacet.field}.facet.sort" => 'index',
       "f.#{xfacet.field}.facet.offset" => offset,
       "f.#{xfacet.field}.facet.limit" => per_page + 2 }

--- a/app/helpers/blacklight_solrplugins/helper_behavior.rb
+++ b/app/helpers/blacklight_solrplugins/helper_behavior.rb
@@ -22,13 +22,25 @@ module BlacklightSolrplugins
       search_action_url(args)
     end
 
+    def build_xbrowse_ref(term_metadata)
+      self_struct = term_metadata['self']
+      prefix = self_struct['prefix']
+      if prefix.nil? || prefix == ''
+        ref = self_struct['filing'] || ''
+      else
+        ref = {'prefix' => prefix, 'filing' => (self_struct['filing'] || '')}
+      end
+      JSON.dump(ref)
+    end
+
     def xbrowse_previous_link(facetwindow, doc_centric: false)
       first = facetwindow.items.first
       if first
+        term_ref = build_xbrowse_ref(first.term_metadata)
         if doc_centric
-          ref = first.docs[0]['id'] + '|' + first.value
+          ref = first.docs[0]['id'] + '|' + term_ref
         else
-          ref = first.value
+          ref = term_ref
         end
         url_for(search_state.params_for_search(ref: ref, dir: "back"))
       end
@@ -37,10 +49,11 @@ module BlacklightSolrplugins
     def xbrowse_next_link(facetwindow, doc_centric: false)
       last = facetwindow.items.last
       if last
+        term_ref = build_xbrowse_ref(last.term_metadata)
         if doc_centric
-          ref = last.docs[0]['id'] + '|' + last.value
+          ref = last.docs[0]['id'] + '|' + term_ref
         else
-          ref = last.value
+          ref = term_ref
         end
         url_for(search_state.params_for_search(ref: ref, dir: "forward"))
       end

--- a/lib/blacklight_solrplugins/facet_field.rb
+++ b/lib/blacklight_solrplugins/facet_field.rb
@@ -34,8 +34,9 @@ module BlacklightSolrplugins
       # flatten the nested structure for doc-centric facet items
       if is_doc_centric
         @items = items.map do |facet_item|
+          term_metadata = facet_item.term_metadata
           facet_item.docs.map do |doc|
-            BlacklightSolrplugins::FacetItem.new(value: facet_item.value, payload: { 'count' => 1, 'docs' => [ doc ] })
+            BlacklightSolrplugins::FacetItem.new(value: facet_item.value, payload: { 'count' => 1, 'termMetadata' => term_metadata, 'docs' => [ doc ] })
           end
         end.flatten
       end

--- a/lib/blacklight_solrplugins/facet_item.rb
+++ b/lib/blacklight_solrplugins/facet_item.rb
@@ -20,7 +20,7 @@ module BlacklightSolrplugins
 
     # available in doc-centric payloads
     def term_metadata
-      payload['termMetadata'] || {}
+      payload['termMetadata'] || payload
     end
 
     # available in doc-centric payloads
@@ -31,7 +31,7 @@ module BlacklightSolrplugins
 
     # returns array of reference types in this FacetItem
     def refs
-      (payload['refs'] || {}).keys || []
+      (term_metadata['refs'] || {}).keys || []
     end
 
     # returns hash of names to counts

--- a/lib/blacklight_solrplugins/response_facets.rb
+++ b/lib/blacklight_solrplugins/response_facets.rb
@@ -36,8 +36,9 @@ module BlacklightSolrplugins
 
           if is_doc_centric
             # flatten the nested structure for doc-centric facet items
+            term_metadata = payload['termMetadata']
             payload['docs'].values.each do |doc|
-              i = create_facet_item(facet_field_name, display_value, { 'count' => 1, 'docs' => [ SolrDocument.new(doc, self) ] })
+              i = create_facet_item(facet_field_name, display_value, { 'count' => 1, 'termMetadata' => term_metadata, 'docs' => [ SolrDocument.new(doc, self) ] })
               items << i
             end
           else


### PR DESCRIPTION
Paging should be based on strict prefix/filing values as parsed from termMetadata, not display value. 

Paging args now must all be valid json, to support exact paging for all xbrowse field types. Instead of paging refs based on display value, parse prefix and filing from termMetadata for both docCentric and term-centric browse.